### PR TITLE
Fix broken links and missing dependency.

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,8 +54,8 @@
 
 <p>The Gregorio project offers tools for typesetting Gregorian chant. These tools include:</p>
 <ul>
-<li><a href="/gregorio/gabc/">gabc</a>: a notation for representing Gregorian chant using ASCII characters</li>
-<li><a href="/gregorio/gregoriotex/">GregorioTeX</a>: a TeX style for typesetting scores</li>
+<li><a href="/gabc/">gabc</a>: a notation for representing Gregorian chant using ASCII characters</li>
+<li><a href="/gregoriotex/">GregorioTeX</a>: a TeX style for typesetting scores</li>
 <li>a software application to convert from gabc to GregorioTeX</li>
 </ul>
 

--- a/installation-linux.html
+++ b/installation-linux.html
@@ -72,7 +72,7 @@ a local copy of the repository of the project, with the command:</p>
 <p class="nofirst">Under Ubuntu/Debian/Mint:</p>
 
 <div class="commandline">
-<code>sudo aptitude install autotools-dev flex bison libltdl7-dev texlive-luatex autopoint python-fontforge</code>
+<code>sudo aptitude install autotools-dev flex bison libltdl7-dev texlive-luatex autopoint python-fontforge libxml2-dev</code>
 </div>
 
 If you're using another distribution, some packages may have a slightly different name.

--- a/installation-linux.html
+++ b/installation-linux.html
@@ -72,7 +72,13 @@ a local copy of the repository of the project, with the command:</p>
 <p class="nofirst">Under Ubuntu/Debian/Mint:</p>
 
 <div class="commandline">
-<code>sudo aptitude install autotools-dev flex bison libltdl7-dev texlive-luatex autopoint python-fontforge libxml2-dev</code>
+<code>sudo aptitude install autotools-dev flex bison libltdl7-dev texlive-luatex autopoint python-fontforge</code>
+</div>
+
+For gregorio versions <4.0, is you are using <span style="font-family: monospace;">--enable-xml-read</span> then this additional dependency is needed:
+
+<div class="commandline">
+  <code>libxml2-dev</code>
 </div>
 
 If you're using another distribution, some packages may have a slightly different name.

--- a/installation-linux.html
+++ b/installation-linux.html
@@ -75,7 +75,7 @@ a local copy of the repository of the project, with the command:</p>
 <code>sudo aptitude install autotools-dev flex bison libltdl7-dev texlive-luatex autopoint python-fontforge</code>
 </div>
 
-For gregorio versions <4.0, is you are using <span style="font-family: monospace;">--enable-xml-read</span> then this additional dependency is needed:
+For gregorio versions &lt;4.0, is you are using <span style="font-family: monospace;">--enable-xml-read</span> then this additional dependency is needed:
 
 <div class="commandline">
   <code>libxml2-dev</code>


### PR DESCRIPTION
Both issues reported on gregorio-users.

I cannot confirm if `libxml2-dev` is a dependency or not for Ubuntu/Debian.
