### PR TITLE
Adding a missing dependency.

### DIFF
--- a/installation-linux.html
+++ b/installation-linux.html
@@ -61,6 +61,13 @@
 
 <p>As Gregorio uses Lua<span class="tex">T<span class="epsilon">e</span>X</span> to produce the final printed socres, you need to obtain a <span class="tex">T<span class="epsilon">e</span>X</span> distribution which contains this engine.  We recommend <span class="tex">T<span class="epsilon">e</span>X</span>Live.  You can get this either via your package manager (in which case make sure you get the Lua<span class="tex">T<span class="epsilon">e</span>X</span> engine and tools, as package managers often split <span class="tex">T<span class="epsilon">e</span>X</span>Live up into multiple packages to reduce the download size) or from the <a href="https://www.tug.org/texlive/"><span class="tex">T<span class="epsilon">e</span>X</span>Live homepage.</a></p>
 
+<p>You will also need the basic package of build tools for your platform.  On Ubuntu/Debian/Mint these can be installed by executing the following in a terminal window:</p>
+
+<div class="commandline">
+    <code>sudo apt-get install build-essential</code>
+</div>
+
+
 <h3>Obtaining Source</h3>
 
 <p>To obtain the sources of the stable version, you just need to download them from the <a href="https://github.com/gregorio-project/gregorio/releases">download page</a>, and decompress the archive.</p>


### PR DESCRIPTION
It appears that my installation of Ubuntu came with compilers pre-loaded, which is not always the case.  It is thus necessary to list the compilers as a dependency.
