### PR TITLE
Clarity for new users

### DIFF
--- a/installation-linux.html
+++ b/installation-linux.html
@@ -85,6 +85,8 @@
     <code>sudo ./install.sh</code>
 </div>
 
+<p>Assuming nither of these commands spit out an error message, then you've successfully installed Gregorio and are ready for the <a href="#next">Next Steps</a>.</p>
+
 <h3>Alternate Installation Locations</h3>
 
 <p>By default the automatic installation process will install gregorio in <code>/usr/local/</code> and Gregorio<span class="tex">T<span class="epsilon">e</span>X</span> into they system-wide texmf-local.  If you wish to change these destinations, then you can add arguments to the build and install instructions to that effect:</p>
@@ -154,9 +156,11 @@ a local copy of the repository of the project, with the command:</p>
 
 <p>To update your git version, you just need to go into the directory containing the source files (assuming you kept them), run <code>git pull</code> and recompile with the same commands.</p>
 
-<h2>Next steps</h2>
+<h2 id="next">Next steps</h2>
 
-<p>If you use <span class="tex">T<span class="epsilon">e</span>X</span>works, it can be very helpful to <a href="./configuration-texworks.html">configure it for Gregorio</a>. Otherwise, you can refer to the <a href="./introduction-commandline.html">command line page</a>.</p>
+<p>If you've used <span class="tex">T<span class="epsilon">e</span>X</span> before, then you probably already have a preferred workflow which will need only minor modifications to make Gregorio work within it.  Please consult the instruction page appropriate to your work flow.  (You can find <a href="./introduction.html">a list of the instruction pages here.</a>)</p>
+
+<p> If you're new to <span class="tex">T<span class="epsilon">e</span>X</span>, we suggest that you make use of <span class="tex">T<span class="epsilon">e</span>X</span>works.  It's a basic IDE (integrated development environment) for using <span class="tex">T<span class="epsilon">e</span>X</span> and family and will provide you with a friendly GUI (graphic user interface).  You will need to <a href="./configuration-texworks.html">configure it for Gregorio</a>.  Once that's done, just follow <a href="./introduction-editor.html">the basic inscrutions for how to use Gregorio</a>.  We also strongly recommend going through <a href="./tutorial/tutorial-gabc-01.html">the tutorial</a> as it provides the easiest introduction to the workflow that we have devised.</p>
 
 <!-- footer -->
     </div>


### PR DESCRIPTION
Added a link to "Next Steps" from the end of the basic installation instructions so that people are less likely to miss them.
Expanded the Next Steps section to add an explicit recommendation for new users to go the IDE route.
