### PR TITLE
Correction gregoriotex/details.html and specific Ubuntu installation hints

### DIFF
--- a/gregoriotex/details.html
+++ b/gregoriotex/details.html
@@ -78,7 +78,7 @@
 
 <h3>Changing the size of a score</h3>
 
-<p>You can change the size of a Gregorio<span class="tex">T<span class="epsilon">e</span>X</span> score simply, by calling the macro <code>\gresetstaffsize{}</code> with a whole number. For example, calling it with 17 (the default value), you will obtain a score whose notes, spaces, etc., will be the same as in the Solesmes Antiphonale (2005).</p>
+<p>You can change the size of a Gregorio<span class="tex">T<span class="epsilon">e</span>X</span> score simply, by calling the macro <code>\grechangestaffsize{}</code> with a whole number. For example, calling it with 17 (the default value), you will obtain a score whose notes, spaces, etc., will be the same as in the Solesmes Antiphonale (2005).</p>
 
 <h3>Modifying the text style</h3>
 

--- a/installation-linux.html
+++ b/installation-linux.html
@@ -85,23 +85,13 @@
     <code>sudo ./install.sh</code>
 </div>
 
-<p>If you are an Ubuntu User there may occur a problem with the second command due to a special behaviour of the <code>sudo</code> command under Ubuntu. Try one of the following workarounds: 1. Try the following alternative command:</p>
+<p>If you are an Ubuntu User there may occur a problem with the second command due to a special behaviour of the <code>sudo</code> command under Ubuntu. Try the following command:</p>
 
 <div class="commandline">
 <code>sudo su ./install.sh</code>
 </div>
 
-<p>2. Search for the exact path of your system-wide texmf-local (command to search for it: <code>kpsewhich -var-value TEXMFLOCAL</code>) and type in:</p>
-
-<div class="commandline">
-<code>sudo ./install.sh dir:/path/to/system-wide/texmf-local</code>
-</div>
-
-<p>3. Install GregorioTex just locally via:</p>
-
-<div class="commandline">
-<code>sudo ./install.sh dir:/home/username/texmf-local</code>
-</div>
+<p>or specify your texmf-local explicitely (see next section). You can find your system-wide texmf-local via <code>kpsewhich -var-value TEXMFLOCAL</code>. The userspecific texmf-local should be: <code>/home/username/texmf-local</code></p>
 
 <h3>Alternate Installation Locations</h3>
 

--- a/installation-linux.html
+++ b/installation-linux.html
@@ -85,6 +85,24 @@
     <code>sudo ./install.sh</code>
 </div>
 
+<p>If you are an Ubuntu User there may occur a problem with the second command due to a special behaviour of the <code>sudo</code> command under Ubuntu. Try one of the following workarounds: 1. Try the following alternative command:</p>
+
+<div class="commandline">
+<code>sudo su ./install.sh</code>
+</div>
+
+<p>2. Search for the exact path of your system-wide texmf-local (command to search for it: <code>kpsewhich -var-value TEXMFLOCAL</code>) and type in:</p>
+
+<div class="commandline">
+<code>sudo ./install.sh dir:/path/to/system-wide/texmf-local</code>
+</div>
+
+<p>3. Install GregorioTex just locally via:</p>
+
+<div class="commandline">
+<code>sudo ./install.sh dir:/home/username/texmf-local</code>
+</div>
+
 <h3>Alternate Installation Locations</h3>
 
 <p>By default the automatic installation process will install gregorio in <code>/usr/local/</code> and Gregorio<span class="tex">T<span class="epsilon">e</span>X</span> into they system-wide texmf-local.  If you wish to change these destinations, then you can add arguments to the build and install instructions to that effect:</p>


### PR DESCRIPTION
Hi, I changed two things: 1. There was a wrong (or outdated?) command in gregoriotex/details.html. To change the staff size one has to use \grechangestaffsize{}, not \gresetstaffsize{}
1. Some users experienced problems installing Gregorio under Ubuntu due to a special behaviour of "sudo". I listed a few possible workarounds. I think it's worth to mention them, since Ubuntu is the most common GNU/Linux distro.

Regards,

martin

PS: If you have any hints or corrections concerning my workflow please let me know. It's my first contribution and I plan to do some more for the website... 
