### PR TITLE
Update Link to TUG

### DIFF
--- a/gregoriotex/tex.html
+++ b/gregoriotex/tex.html
@@ -79,7 +79,7 @@
 
 <p>Be aware in advance that learning <span class="latex">L<span class="alpha">a</span>T<span class="epsilon">e</span>X</span> will demand of you time and energy. When you're used to software with a graphical interface, it is easy to be disoriented or discouraged at the learning curve of a language such as <span class="tex">T<span class="epsilon">e</span>X</span>.  In the meantime, after some effort at the outset, the language reveals itself to be very powerful and the renderings more than satisfactory.</p>
 
-<p>To learn <span class="latex">L<span class="alpha">a</span>T<span class="epsilon">e</span>X</span>, a lot of tutorials are available on the net, as well as several excellent books. Here is an <a href="http://www.tug.org.in/tutorials.html">example of a tutorial</a>.</p>
+<p>To learn <span class="latex">L<span class="alpha">a</span>T<span class="epsilon">e</span>X</span>, a lot of tutorials are available on the net, as well as several excellent books. To get you started, here is the <a href="http://www.tug.org/begin.html">TUG introduction</a> (TUG, the <span class="tex">T<span class="epsilon">e</span>X</span> Users Group, is the non-profit which maintains the <span class="tex">T<span class="epsilon">e</span>X</span>Live distribution, quite possibly the most popular <span class="tex">T<span class="epsilon">e</span>X</span> distribution).</p>
 
 <h2>What are the different versions of <span class="tex">T<span class="epsilon">e</span>X</span>?</h2>
 


### PR DESCRIPTION
TUG's tutorial on LaTeX no longer exists, so we link to the TeX introduction instead.