### PR TITLE
underline tag is <ul>, not <u>

### DIFF
--- a/gabc/index.html
+++ b/gabc/index.html
@@ -500,7 +500,7 @@ secondary w W;</code>
 
 <h3 id="textstyle">Text style</h3>
 
-<p>Even though text is rarely styled in a chant score, gabc allows for some markup to apply styles to the text: they are <code>&lt;i&gt;</code> for italic, <code>&lt;b&gt;</code> for bold, <code>&lt;u&gt;</code> for underline (does not work in Plain <span class="tex">T<span class="epsilon">e</span>X</span>), <code>&lt;c&gt;</code> for colored (specifically in <code>gregoriocolor</code>), and <code>&lt;sc&gt;</code> for small capitals.</p>
+<p>Even though text is rarely styled in a chant score, gabc allows for some markup to apply styles to the text: they are <code>&lt;i&gt;</code> for italic, <code>&lt;b&gt;</code> for bold, <code>&lt;ul&gt;</code> for underline (does not work in Plain <span class="tex">T<span class="epsilon">e</span>X</span>), <code>&lt;c&gt;</code> for colored (specifically in <code>gregoriocolor</code>), and <code>&lt;sc&gt;</code> for small capitals.</p>
 
 <p>For example: <code>&lt;i&gt;Ps.&lt;/i&gt;(::)</code></p>
 

--- a/gabc/summary-gabc.tex
+++ b/gabc/summary-gabc.tex
@@ -124,7 +124,7 @@ gh<v>[</v>ocba:0<v>\}]</v>(gh[ocba:0}])
 				<b>bold</b> & \GreBold{bold}\\
 				<i>italic</i> & \GreItalic{italic}\\
 				<c>color</c> & \GreColored{color}\\
-				<u>underline</u> & \GreUnderline{underline}\\
+				<ul>underline</ul> & \GreUnderline{underline}\\
 				<sc>small caps</sc> & \GreSmallCaps{small caps}\\
 			\end{supertabular}
 		\end{center}


### PR DESCRIPTION
I'm not sure if `<u>` is a remnant from some old Gregorio version or simply incorrect from the beginning. Gregorio changelog doesn't mention any change to the underline tag.

(I did try also to rebuild `gabc/summary-gabc.pdf`, but failed.)