### PR TITLE
Fix broken links in tutorial-gabc-01.html

### DIFF
--- a/tutorial/tutorial-gabc-01.html
+++ b/tutorial/tutorial-gabc-01.html
@@ -65,7 +65,7 @@
 
 <p>Documentation for the gabc notation which we use in this tutorial can be found <a href="../gabc/index.html">here</a>.  We will also link to the various parts of the documentation as it becomes relavent.  A <a href="../gabc/summary-gabc.pdf">one-page summary is also on-line</a> (PDF).</p>
 
-<p>In this tutorial we’ll be using the <a href="http://apps.illuminarepublications.com/gregorio/">Illuminare Score Editor</a> and all the images will be derived from that tool because it has a built-in preview window that gives us nearly instantaneous feedback about what we’re doing. However, you could also use the <a href="http://gregorio.gabrielmass.com/cgi/process.pl">Gregorio Chant Engraver</a> if you prefer that.  Obviously the images won’t match and some of the specific interface issues are different (including the lack of an instant preview), but the gabc itself is identical and we are specifically going to focus on that gabc notation.  This makes for a much easier introduction for those not familiar with <span class="tex">T<span class="epsilon">e</span>X</span>.  Once you’re comfortable with gabc notation, then you’ll find learning how to integrate it into larger projects using <span class="tex">T<span class="epsilon">e</span>X</span> much easier (as is done in our <a href="./tutorials.html">other tutorials</a>).</p>
+<p>In this tutorial we’ll be using the <a href="https://www.sourceandsummit.com/editor/legacy/">Illuminare Score Editor</a> and all the images will be derived from that tool because it has a built-in preview window that gives us nearly instantaneous feedback about what we’re doing. However, you could also use the <a href="http://gregorio.gabrielmass.com/cgi/process.pl">Gregorio Chant Engraver</a> if you prefer that.  Obviously the images won’t match and some of the specific interface issues are different (including the lack of an instant preview), but the gabc itself is identical and we are specifically going to focus on that gabc notation.  This makes for a much easier introduction for those not familiar with <span class="tex">T<span class="epsilon">e</span>X</span>.  Once you’re comfortable with gabc notation, then you’ll find learning how to integrate it into larger projects using <span class="tex">T<span class="epsilon">e</span>X</span> much easier (as is done in our <a href="./tutorials.html">other tutorials</a>).</p>
 
 <h2>Exaudivit</h2>
 
@@ -77,7 +77,7 @@
 
 <p>It’s not the simplest score in the world, but it is not overly complicated either and it illustrates several of the most common features of Gregorian chant allowing us to call out how to represent these using gabc as we go.</p>
 
-<p>Obviously the first step is to fire up <a href="http://apps.illuminarepublications.com/gregorio/">Illuminare Score Editor</a>.  When we do so we get a screen that looks like this:</p>
+<p>Obviously the first step is to fire up <a href="https://www.sourceandsummit.com/editor/legacy/">Illuminare Score Editor</a>.  When we do so we get a screen that looks like this:</p>
 
 <div class="legende">
 <a href="Exaudivit-01.png"><img src="Exaudivit-01.png" alt="Illuminare Score Editor on open.  Click to enlarge..." width=500/></a>


### PR DESCRIPTION
This revision updates "tutorial-gabc-01.html" to fix the broken links to the Illuminare Score Editor.